### PR TITLE
Version 1.0.2 - Float80 Fix

### DIFF
--- a/Sources/SwiftyData/Extensions/Datatypes/Float+Init.swift
+++ b/Sources/SwiftyData/Extensions/Datatypes/Float+Init.swift
@@ -10,7 +10,7 @@ public extension Float {
     }
 }
 
-@available(iOS 11, *)
+#if os(macOS)
 public extension Float80 {
     init?(_ data: Data) {
         //Convert Data and check that it return something else return nil
@@ -18,3 +18,4 @@ public extension Float80 {
         self = value
     }
 }
+#endif

--- a/Sources/SwiftyData/Extensions/Datatypes/Float+Init.swift
+++ b/Sources/SwiftyData/Extensions/Datatypes/Float+Init.swift
@@ -10,6 +10,7 @@ public extension Float {
     }
 }
 
+@available(iOS 11, *)
 public extension Float80 {
     init?(_ data: Data) {
         //Convert Data and check that it return something else return nil

--- a/Tests/SwiftyDataTests/Datatypes/FloatTests.swift
+++ b/Tests/SwiftyDataTests/Datatypes/FloatTests.swift
@@ -58,63 +58,6 @@ final class FloatTests: XCTestCase {
         //Check if data equals given Float
         XCTAssertEqual(converted, sample)
     }
-    
-    
-    //MARK: - Float80 (80 Bit -> 16 Byte [Allocates more bytes that it needs])
-
-    func testFloat80Conversion() {
-        let sample: Float80 = 68347.83928839299
-        let sampleDataInUInt8: [UInt8] = [248, 230, 83, 205, 109, 235, 125, 133,
-                                          15, 64, 187, 80, 255, 127, 0, 0]
-        
-        //Convert Float80 To Data
-        let data = Data(sample)
-        
-        //Make Iterator and create array
-        var dataInUInt8: [UInt8] = [UInt8]()
-        var dataIterator = data.makeIterator()
-        
-        //Iterate over all objects in the iterator and add them to the array
-        while let byte = dataIterator.next() {
-            dataInUInt8.append(byte)
-        }
-        
-        //Check if data equals given data
-        XCTAssertEqual(dataInUInt8, sampleDataInUInt8)
-        
-        //Convert data back to Float80
-        let converted = Float80(data)
-        
-        //Check if data equals given Float80
-        XCTAssertEqual(converted, sample)
-    }
-    
-    func testNegativeFloat80Conversion() {
-        let sample: Float80 = -68347.83928839299
-        let sampleDataInUInt8: [UInt8] = [248, 230, 83, 205, 109, 235, 125, 133,
-                                          15, 192, 187, 80, 255, 127, 0, 0]
-        
-        //Convert Float80 To Data
-        let data = Data(sample)
-        
-        //Make Iterator and create array
-        var dataInUInt8: [UInt8] = [UInt8]()
-        var dataIterator = data.makeIterator()
-        
-        //Iterate over all objects in the iterator and add them to the array
-        while let byte = dataIterator.next() {
-            dataInUInt8.append(byte)
-        }
-        
-        //Check if data equals given data
-        XCTAssertEqual(dataInUInt8, sampleDataInUInt8)
-        
-        //Convert data back to Float80
-        let converted = Float80(data)
-        
-        //Check if data equals given Float80
-        XCTAssertEqual(converted, sample)
-    }
 
     
     //MARK: - Float64 (64 Bit -> 8 Byte)
@@ -233,10 +176,7 @@ final class FloatTests: XCTestCase {
     static var allTests = [
         ("testFloatConversion", testFloatConversion),
         ("testNegativeFloatConversion", testNegativeFloatConversion),
-        
-        ("testFloat80Conversion", testFloat80Conversion),
-        ("testNegativeFloat80Conversion", testNegativeFloat80Conversion),
-        
+    
         ("testFloat64Conversion", testFloat64Conversion),
         ("testNegativeFloat64Conversion", testNegativeFloat64Conversion),
         


### PR DESCRIPTION
Removed Float80 extension and tests because this datatype is not available on iOS.